### PR TITLE
feat: implement event sourcing for customer records

### DIFF
--- a/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerChange.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerChange.cs
@@ -1,0 +1,4 @@
+namespace Modules.Customer.Application.ReadModels;
+
+public sealed record CustomerChange(long Version, string Type, DateTimeOffset OccurredOnUtc);
+

--- a/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerNotificationPreferences.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerNotificationPreferences.cs
@@ -1,0 +1,7 @@
+namespace Modules.Customer.Application.ReadModels;
+
+public sealed record CustomerNotificationPreferences(
+    Guid Id,
+    bool EmailNotificationsEnabled,
+    bool SmsNotificationsEnabled);
+

--- a/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerProfile.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerProfile.cs
@@ -1,0 +1,11 @@
+namespace Modules.Customer.Application.ReadModels;
+
+public sealed record CustomerProfile(
+    Guid Id,
+    string Title,
+    string FirstName,
+    string LastName,
+    string Email,
+    bool EmailNotificationsEnabled,
+    bool SmsNotificationsEnabled);
+

--- a/src/Modules/Customer/Modules.Customer.Application/Services/CustomerReadService.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/Services/CustomerReadService.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Application.Lifetimes;
+using Modules.Customer.Application.ReadModels;
+using Modules.Customer.Domain.Abstractions;
+using Modules.Customer.Domain.Entities;
+
+namespace Modules.Customer.Application.Services;
+
+public sealed class CustomerReadService(ICustomerEventStore eventStore) : ICustomerReadService, ITransient
+{
+    private readonly ICustomerEventStore _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+
+    public async Task<CustomerProfile?> GetProfileAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var events = await _eventStore.LoadAsync(customerId, cancellationToken);
+        if (events.Count == 0)
+        {
+            return null;
+        }
+
+        var customer = Customer.Rehydrate(events);
+
+        return new CustomerProfile(
+            customer.Id,
+            customer.Title,
+            customer.FirstName,
+            customer.LastName,
+            customer.ContactInformation.Email,
+            customer.EmailNotificationsEnabled,
+            customer.SmsNotificationsEnabled);
+    }
+
+    public async Task<IReadOnlyList<CustomerChange>> GetChangeHistoryAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var history = await _eventStore.GetHistoryAsync(customerId, cancellationToken);
+        return history.Select(e => new CustomerChange(e.Version, e.Type, e.OccurredOnUtc)).ToList();
+    }
+
+    public async Task<CustomerNotificationPreferences?> GetNotificationPreferencesAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var events = await _eventStore.LoadAsync(customerId, cancellationToken);
+        if (events.Count == 0)
+        {
+            return null;
+        }
+
+        var customer = Customer.Rehydrate(events);
+
+        return new CustomerNotificationPreferences(
+            customer.Id,
+            customer.EmailNotificationsEnabled,
+            customer.SmsNotificationsEnabled);
+    }
+}
+

--- a/src/Modules/Customer/Modules.Customer.Application/Services/ICustomerReadService.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/Services/ICustomerReadService.cs
@@ -1,0 +1,11 @@
+using Modules.Customer.Application.ReadModels;
+
+namespace Modules.Customer.Application.Services;
+
+public interface ICustomerReadService
+{
+    Task<CustomerProfile?> GetProfileAsync(Guid customerId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CustomerChange>> GetChangeHistoryAsync(Guid customerId, CancellationToken cancellationToken = default);
+    Task<CustomerNotificationPreferences?> GetNotificationPreferencesAsync(Guid customerId, CancellationToken cancellationToken = default);
+}
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Abstractions/ICustomerEventStore.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Abstractions/ICustomerEventStore.cs
@@ -1,0 +1,12 @@
+using Domain.Primitives;
+using Modules.Customer.Domain.Entities;
+
+namespace Modules.Customer.Domain.Abstractions;
+
+public interface ICustomerEventStore
+{
+    Task AppendAsync(Customer customer, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<IDomainEvent>> LoadAsync(Guid customerId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<StoredEvent>> GetHistoryAsync(Guid customerId, CancellationToken cancellationToken = default);
+}
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Abstractions/StoredEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Abstractions/StoredEvent.cs
@@ -1,0 +1,4 @@
+namespace Modules.Customer.Domain.Abstractions;
+
+public sealed record StoredEvent(string Type, string Data, long Version, DateTimeOffset OccurredOnUtc);
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Entities/ContactInformation.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Entities/ContactInformation.cs
@@ -1,5 +1,5 @@
-﻿using Domain.Primitives;
-
+using Domain.Primitives;
+using System.Text.Json.Serialization;
 
 namespace Modules.Customer.Domain.Entities;
 
@@ -15,7 +15,8 @@ public sealed class ContactInformation : Entity<Guid>
     public string Postcode { get; set; } = string.Empty;
     public string County { get; set; } = string.Empty;
     public string Country { get; set; } = string.Empty;
-    public Customer Customer { get; set; } = null!;
 
+    [JsonIgnore]
+    public Customer Customer { get; set; } = null!;
 }
 

--- a/src/Modules/Customer/Modules.Customer.Domain/Entities/Customer.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Entities/Customer.cs
@@ -1,17 +1,130 @@
 using Domain.Primitives;
-using Domain.ValueObjects;
-using System.Xml.Linq;
+using Modules.Customer.Domain.Events;
 
 namespace Modules.Customer.Domain.Entities;
-public sealed class Customer : Entity<Guid>
+
+public sealed class Customer : AggregateRoot<Guid>
 {
-    public Guid TenantId { get; set; }
-    public Guid UserId { get; set; }
-    public string Title { get; set; } = string.Empty;
-    public string FirstName { get; set; } = string.Empty;
-    public string LastName { get; set; } = string.Empty;
-    public DateOnly DateOfBirth { get; set; }
-    public string Gender { get; set; } = string.Empty;
-    public ContactInformation ContactInformation { get; set; } = null!;
-  
+    public Guid TenantId { get; private set; }
+    public Guid UserId { get; private set; }
+    public string Title { get; private set; } = string.Empty;
+    public string FirstName { get; private set; } = string.Empty;
+    public string LastName { get; private set; } = string.Empty;
+    public DateOnly DateOfBirth { get; private set; }
+    public string Gender { get; private set; } = string.Empty;
+    public ContactInformation ContactInformation { get; private set; } = new();
+    public bool EmailNotificationsEnabled { get; private set; }
+    public bool SmsNotificationsEnabled { get; private set; }
+
+    private Customer() { }
+
+    private Customer(Guid id) : base(id) { }
+
+    public static Customer Create(
+        Guid id,
+        Guid tenantId,
+        Guid userId,
+        string title,
+        string firstName,
+        string lastName,
+        DateOnly dateOfBirth,
+        string gender,
+        ContactInformation contactInformation,
+        bool emailNotificationsEnabled,
+        bool smsNotificationsEnabled)
+    {
+        var customer = new Customer(id);
+        var @event = new CustomerCreatedDomainEvent(
+            id,
+            tenantId,
+            userId,
+            title,
+            firstName,
+            lastName,
+            dateOfBirth,
+            gender,
+            contactInformation,
+            emailNotificationsEnabled,
+            smsNotificationsEnabled);
+        customer.ApplyChange(@event);
+        return customer;
+    }
+
+    public void UpdateDetails(
+        string title,
+        string firstName,
+        string lastName,
+        DateOnly dateOfBirth,
+        string gender,
+        ContactInformation contactInformation)
+    {
+        var @event = new CustomerDetailsUpdatedDomainEvent(
+            Id,
+            title,
+            firstName,
+            lastName,
+            dateOfBirth,
+            gender,
+            contactInformation);
+        ApplyChange(@event);
+    }
+
+    public void UpdatePreferences(bool emailNotificationsEnabled, bool smsNotificationsEnabled)
+    {
+        var @event = new CustomerPreferencesUpdatedDomainEvent(
+            Id,
+            emailNotificationsEnabled,
+            smsNotificationsEnabled);
+        ApplyChange(@event);
+    }
+
+    public void Delete()
+    {
+        var @event = new CustomerDeletedDomainEvent(Id);
+        ApplyChange(@event);
+    }
+
+    private void On(CustomerCreatedDomainEvent @event)
+    {
+        Id = @event.CustomerId;
+        TenantId = @event.TenantId;
+        UserId = @event.UserId;
+        Title = @event.Title;
+        FirstName = @event.FirstName;
+        LastName = @event.LastName;
+        DateOfBirth = @event.DateOfBirth;
+        Gender = @event.Gender;
+        ContactInformation = @event.ContactInformation;
+        EmailNotificationsEnabled = @event.EmailNotificationsEnabled;
+        SmsNotificationsEnabled = @event.SmsNotificationsEnabled;
+    }
+
+    private void On(CustomerDetailsUpdatedDomainEvent @event)
+    {
+        Title = @event.Title;
+        FirstName = @event.FirstName;
+        LastName = @event.LastName;
+        DateOfBirth = @event.DateOfBirth;
+        Gender = @event.Gender;
+        ContactInformation = @event.ContactInformation;
+    }
+
+    private void On(CustomerPreferencesUpdatedDomainEvent @event)
+    {
+        EmailNotificationsEnabled = @event.EmailNotificationsEnabled;
+        SmsNotificationsEnabled = @event.SmsNotificationsEnabled;
+    }
+
+    private void On(CustomerDeletedDomainEvent _)
+    {
+        DeletedAt = DateTime.UtcNow;
+    }
+
+    public static Customer Rehydrate(IEnumerable<IDomainEvent> events)
+    {
+        var customer = new Customer();
+        customer.Load(events);
+        return customer;
+    }
 }
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerCreatedDomainEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerCreatedDomainEvent.cs
@@ -1,0 +1,19 @@
+using Domain.Primitives;
+using Modules.Customer.Domain.Entities;
+
+namespace Modules.Customer.Domain.Events;
+
+public sealed record CustomerCreatedDomainEvent(
+    Guid CustomerId,
+    Guid TenantId,
+    Guid UserId,
+    string Title,
+    string FirstName,
+    string LastName,
+    DateOnly DateOfBirth,
+    string Gender,
+    ContactInformation ContactInformation,
+    bool EmailNotificationsEnabled,
+    bool SmsNotificationsEnabled
+) : DomainEvent(DateTimeOffset.UtcNow);
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerDeletedDomainEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerDeletedDomainEvent.cs
@@ -1,0 +1,8 @@
+using Domain.Primitives;
+
+namespace Modules.Customer.Domain.Events;
+
+public sealed record CustomerDeletedDomainEvent(
+    Guid CustomerId
+) : DomainEvent(DateTimeOffset.UtcNow);
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerDetailsUpdatedDomainEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerDetailsUpdatedDomainEvent.cs
@@ -1,0 +1,15 @@
+using Domain.Primitives;
+using Modules.Customer.Domain.Entities;
+
+namespace Modules.Customer.Domain.Events;
+
+public sealed record CustomerDetailsUpdatedDomainEvent(
+    Guid CustomerId,
+    string Title,
+    string FirstName,
+    string LastName,
+    DateOnly DateOfBirth,
+    string Gender,
+    ContactInformation ContactInformation
+) : DomainEvent(DateTimeOffset.UtcNow);
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerPreferencesUpdatedDomainEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerPreferencesUpdatedDomainEvent.cs
@@ -1,0 +1,10 @@
+using Domain.Primitives;
+
+namespace Modules.Customer.Domain.Events;
+
+public sealed record CustomerPreferencesUpdatedDomainEvent(
+    Guid CustomerId,
+    bool EmailNotificationsEnabled,
+    bool SmsNotificationsEnabled
+) : DomainEvent(DateTimeOffset.UtcNow);
+

--- a/src/Modules/Customer/Modules.Customer.Infrastructure/EventStore/CustomerEventStore.cs
+++ b/src/Modules/Customer/Modules.Customer.Infrastructure/EventStore/CustomerEventStore.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using System.Linq;
+using Application.Lifetimes;
+using Domain.Primitives;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Modules.Customer.Domain.Abstractions;
+using Modules.Customer.Domain.Entities;
+using Modules.Customer.Persistence;
+using Modules.Customer.Persistence.Entities;
+
+namespace Modules.Customer.Infrastructure.EventStore;
+
+public sealed class CustomerEventStore(CustomerDbContext dbContext, IMediator mediator) : ICustomerEventStore, IScoped
+{
+    private readonly CustomerDbContext _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    private readonly IMediator _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task AppendAsync(Customer customer, CancellationToken cancellationToken = default)
+    {
+        var events = customer.DomainEvents;
+        var lastVersion = await _dbContext.CustomerEvents
+            .Where(e => e.CustomerId == customer.Id)
+            .OrderByDescending(e => e.Version)
+            .Select(e => e.Version)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (customer.Version - events.Count != lastVersion)
+        {
+            throw new InvalidOperationException("Concurrency conflict detected.");
+        }
+
+        var nextVersion = lastVersion;
+        foreach (var domainEvent in events)
+        {
+            nextVersion++;
+            var serialized = JsonSerializer.Serialize(domainEvent, domainEvent.GetType(), _jsonOptions);
+            _dbContext.CustomerEvents.Add(new CustomerEvent
+            {
+                Id = Guid.NewGuid(),
+                CustomerId = customer.Id,
+                Type = domainEvent.GetType().AssemblyQualifiedName!,
+                Data = serialized,
+                Version = nextVersion,
+                OccurredOnUtc = domainEvent.OccurredOnUtc
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        foreach (var domainEvent in events)
+        {
+            var committedType = typeof(CommittedDomainEvent<>).MakeGenericType(domainEvent.GetType());
+            var committed = Activator.CreateInstance(committedType, domainEvent);
+            if (committed is INotification notification)
+            {
+                await _mediator.Publish(notification, cancellationToken);
+            }
+        }
+
+        customer.ClearDomainEvents();
+    }
+
+    public async Task<IReadOnlyList<IDomainEvent>> LoadAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var eventEntities = await _dbContext.CustomerEvents
+            .Where(e => e.CustomerId == customerId)
+            .OrderBy(e => e.Version)
+            .ToListAsync(cancellationToken);
+
+        var events = new List<IDomainEvent>();
+        foreach (var entity in eventEntities)
+        {
+            var type = Type.GetType(entity.Type);
+            if (type is null)
+            {
+                continue;
+            }
+
+            var domainEvent = (IDomainEvent?)JsonSerializer.Deserialize(entity.Data, type, _jsonOptions);
+            if (domainEvent is not null)
+            {
+                events.Add(domainEvent);
+            }
+        }
+
+        return events;
+    }
+
+    public async Task<IReadOnlyList<StoredEvent>> GetHistoryAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var eventEntities = await _dbContext.CustomerEvents
+            .Where(e => e.CustomerId == customerId)
+            .OrderBy(e => e.Version)
+            .ToListAsync(cancellationToken);
+
+        return eventEntities
+            .Select(e => new StoredEvent(e.Type, e.Data, e.Version, e.OccurredOnUtc))
+            .ToList();
+    }
+}
+

--- a/src/Modules/Customer/Modules.Customer.Persistence/Configurations/CustomerEventConfiguration.cs
+++ b/src/Modules/Customer/Modules.Customer.Persistence/Configurations/CustomerEventConfiguration.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Modules.Customer.Persistence.Entities;
+
+namespace Modules.Customer.Persistence.Configurations;
+
+public sealed class CustomerEventConfiguration : IEntityTypeConfiguration<CustomerEvent>
+{
+    public void Configure(EntityTypeBuilder<CustomerEvent> builder)
+    {
+        builder.ToTable("customer_events");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).ValueGeneratedNever();
+        builder.Property(e => e.Type).IsRequired();
+        builder.Property(e => e.Data).IsRequired();
+        builder.Property(e => e.Version).IsRequired();
+        builder.Property(e => e.OccurredOnUtc).IsRequired();
+        builder.HasIndex(e => new { e.CustomerId, e.Version }).IsUnique();
+    }
+}
+

--- a/src/Modules/Customer/Modules.Customer.Persistence/CustomerDbContext.cs
+++ b/src/Modules/Customer/Modules.Customer.Persistence/CustomerDbContext.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Persistence.Extensions;
 using Modules.Customer.Domain.Entities;
+using Modules.Customer.Persistence.Entities;
 
 namespace Modules.Customer.Persistence;
 
@@ -17,6 +18,7 @@ public class CustomerDbContext: DbContext
 
     public DbSet<ContactInformation> ContactInformations => Set<ContactInformation>();
     public DbSet<Domain.Entities.Customer> Customers => Set<Domain.Entities.Customer>();
+    public DbSet<CustomerEvent> CustomerEvents => Set<CustomerEvent>();
     
     /// <inheritdoc />
     protected override void OnModelCreating(

--- a/src/Modules/Customer/Modules.Customer.Persistence/Entities/CustomerEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Persistence/Entities/CustomerEvent.cs
@@ -1,0 +1,12 @@
+namespace Modules.Customer.Persistence.Entities;
+
+public sealed class CustomerEvent
+{
+    public Guid Id { get; set; }
+    public Guid CustomerId { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string Data { get; set; } = string.Empty;
+    public long Version { get; set; }
+    public DateTimeOffset OccurredOnUtc { get; set; }
+}
+

--- a/src/Shared/Domain/Primitives/AggregateRoot.cs
+++ b/src/Shared/Domain/Primitives/AggregateRoot.cs
@@ -1,0 +1,55 @@
+namespace Domain.Primitives;
+
+/// <summary>
+/// Base class for aggregate roots supporting event sourcing.
+/// </summary>
+/// <typeparam name="TEntityId">The entity identifier type.</typeparam>
+public abstract class AggregateRoot<TEntityId> : Entity<TEntityId>, IAggregate<TEntityId>
+    where TEntityId : notnull
+{
+    protected AggregateRoot() { }
+
+    protected AggregateRoot(TEntityId id) : base(id) { }
+
+    /// <inheritdoc />
+    public IReadOnlyList<IDomainEvent> DomainEvents => GetDomainEvents();
+
+    /// <inheritdoc />
+    public long Version { get; set; } = -1;
+
+    /// <summary>
+    /// Applies and records a new domain event.
+    /// </summary>
+    /// <param name="domainEvent">The domain event.</param>
+    protected void ApplyChange(IDomainEvent domainEvent)
+    {
+        When(domainEvent);
+        RaiseDomainEvent(domainEvent);
+        Version++;
+    }
+
+    /// <summary>
+    /// Applies a historical event without recording it.
+    /// </summary>
+    /// <param name="domainEvent">The domain event.</param>
+    protected void Apply(IDomainEvent domainEvent)
+    {
+        When(domainEvent);
+        Version++;
+    }
+
+    /// <summary>
+    /// Loads the aggregate state from a sequence of domain events.
+    /// </summary>
+    /// <param name="history">The domain events history.</param>
+    public void Load(IEnumerable<IDomainEvent> history)
+    {
+        foreach (var domainEvent in history)
+        {
+            Apply(domainEvent);
+        }
+    }
+
+    private void When(IDomainEvent domainEvent) => ((dynamic)this).On((dynamic)domainEvent);
+}
+


### PR DESCRIPTION
## Summary
- introduce event-sourced Customer aggregate with versioned domain events
- persist customer events in append-only store and publish committed events
- add CQRS read models for profiles, history, and notification preferences

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad654f7e388328b5abdd76b243ec46