### PR TITLE
feat: implement event sourcing for customer records

### DIFF
--- a/src/Modules/Customer/Modules.Customer.Application/Projections/CustomerChangeHistoryProjection.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/Projections/CustomerChangeHistoryProjection.cs
@@ -1,0 +1,63 @@
+using Domain.Primitives;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Modules.Customer.Domain.Events;
+using Modules.Customer.Persistence;
+using Modules.Customer.Persistence.ReadModels;
+
+namespace Modules.Customer.Application.Projections;
+
+public sealed class CustomerChangeHistoryProjection :
+    INotificationHandler<ICommittedDomainEvent<CustomerCreatedDomainEvent>>,
+    INotificationHandler<ICommittedDomainEvent<CustomerDetailsUpdatedDomainEvent>>,
+    INotificationHandler<ICommittedDomainEvent<CustomerPreferencesUpdatedDomainEvent>>,
+    INotificationHandler<ICommittedDomainEvent<CustomerDeletedDomainEvent>>
+{
+    private readonly CustomerReadDbContext _dbContext;
+
+    public CustomerChangeHistoryProjection(CustomerReadDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerCreatedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        await AddChange(notification.Event.CustomerId, nameof(CustomerCreatedDomainEvent), notification.Event.OccurredOnUtc, cancellationToken);
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerDetailsUpdatedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        await AddChange(notification.Event.CustomerId, nameof(CustomerDetailsUpdatedDomainEvent), notification.Event.OccurredOnUtc, cancellationToken);
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerPreferencesUpdatedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        await AddChange(notification.Event.CustomerId, nameof(CustomerPreferencesUpdatedDomainEvent), notification.Event.OccurredOnUtc, cancellationToken);
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerDeletedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        await AddChange(notification.Event.CustomerId, nameof(CustomerDeletedDomainEvent), notification.Event.OccurredOnUtc, cancellationToken);
+    }
+
+    private async Task AddChange(Guid customerId, string type, DateTimeOffset occurredOnUtc, CancellationToken cancellationToken)
+    {
+        var version = await _dbContext.CustomerChanges
+            .Where(c => c.CustomerId == customerId)
+            .OrderByDescending(c => c.Version)
+            .Select(c => c.Version)
+            .FirstOrDefaultAsync(cancellationToken) + 1;
+
+        _dbContext.CustomerChanges.Add(new CustomerChangeReadModel
+        {
+            Id = Guid.NewGuid(),
+            CustomerId = customerId,
+            Version = version,
+            Type = type,
+            OccurredOnUtc = occurredOnUtc
+        });
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}
+

--- a/src/Modules/Customer/Modules.Customer.Application/Projections/CustomerNotificationPreferencesProjection.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/Projections/CustomerNotificationPreferencesProjection.cs
@@ -1,0 +1,63 @@
+using Domain.Primitives;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Modules.Customer.Domain.Events;
+using Modules.Customer.Persistence;
+using Modules.Customer.Persistence.ReadModels;
+
+namespace Modules.Customer.Application.Projections;
+
+public sealed class CustomerNotificationPreferencesProjection :
+    INotificationHandler<ICommittedDomainEvent<CustomerCreatedDomainEvent>>,
+    INotificationHandler<ICommittedDomainEvent<CustomerPreferencesUpdatedDomainEvent>>,
+    INotificationHandler<ICommittedDomainEvent<CustomerDeletedDomainEvent>>
+{
+    private readonly CustomerReadDbContext _dbContext;
+
+    public CustomerNotificationPreferencesProjection(CustomerReadDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerCreatedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        var e = notification.Event;
+
+        _dbContext.CustomerNotificationPreferences.Add(new CustomerNotificationPreferencesReadModel
+        {
+            CustomerId = e.CustomerId,
+            EmailNotificationsEnabled = e.EmailNotificationsEnabled,
+            SmsNotificationsEnabled = e.SmsNotificationsEnabled
+        });
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerPreferencesUpdatedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        var e = notification.Event;
+
+        var prefs = await _dbContext.CustomerNotificationPreferences.FirstOrDefaultAsync(p => p.CustomerId == e.CustomerId, cancellationToken);
+        if (prefs is not null)
+        {
+            prefs.EmailNotificationsEnabled = e.EmailNotificationsEnabled;
+            prefs.SmsNotificationsEnabled = e.SmsNotificationsEnabled;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerDeletedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        var e = notification.Event;
+
+        var prefs = await _dbContext.CustomerNotificationPreferences.FirstOrDefaultAsync(p => p.CustomerId == e.CustomerId, cancellationToken);
+        if (prefs is not null)
+        {
+            _dbContext.CustomerNotificationPreferences.Remove(prefs);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}
+

--- a/src/Modules/Customer/Modules.Customer.Application/Projections/CustomerReadModelProjection.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/Projections/CustomerReadModelProjection.cs
@@ -1,0 +1,157 @@
+using Domain.Primitives;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Modules.Customer.Domain.Events;
+using Modules.Customer.Persistence;
+using Modules.Customer.Persistence.ReadModels;
+
+namespace Modules.Customer.Application.Projections;
+
+public sealed class CustomerReadModelProjection :
+    INotificationHandler<ICommittedDomainEvent<CustomerCreatedDomainEvent>>,
+    INotificationHandler<ICommittedDomainEvent<CustomerDetailsUpdatedDomainEvent>>,
+    INotificationHandler<ICommittedDomainEvent<CustomerPreferencesUpdatedDomainEvent>>,
+    INotificationHandler<ICommittedDomainEvent<CustomerDeletedDomainEvent>>
+{
+    private readonly CustomerReadDbContext _dbContext;
+
+    public CustomerReadModelProjection(CustomerReadDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerCreatedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        var e = notification.Event;
+
+        _dbContext.CustomerProfiles.Add(new CustomerProfileReadModel
+        {
+            Id = e.CustomerId,
+            Title = e.Title,
+            FirstName = e.FirstName,
+            LastName = e.LastName,
+            Email = e.ContactInformation.Email,
+            EmailNotificationsEnabled = e.EmailNotificationsEnabled,
+            SmsNotificationsEnabled = e.SmsNotificationsEnabled
+        });
+
+        _dbContext.CustomerNotificationPreferences.Add(new CustomerNotificationPreferencesReadModel
+        {
+            CustomerId = e.CustomerId,
+            EmailNotificationsEnabled = e.EmailNotificationsEnabled,
+            SmsNotificationsEnabled = e.SmsNotificationsEnabled
+        });
+
+        _dbContext.CustomerChanges.Add(new CustomerChangeReadModel
+        {
+            Id = Guid.NewGuid(),
+            CustomerId = e.CustomerId,
+            Version = 1,
+            Type = nameof(CustomerCreatedDomainEvent),
+            OccurredOnUtc = e.OccurredOnUtc
+        });
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerDetailsUpdatedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        var e = notification.Event;
+
+        var profile = await _dbContext.CustomerProfiles.FirstOrDefaultAsync(p => p.Id == e.CustomerId, cancellationToken);
+        if (profile is not null)
+        {
+            profile.Title = e.Title;
+            profile.FirstName = e.FirstName;
+            profile.LastName = e.LastName;
+            profile.Email = e.ContactInformation.Email;
+        }
+
+        var version = await _dbContext.CustomerChanges
+            .Where(c => c.CustomerId == e.CustomerId)
+            .OrderByDescending(c => c.Version)
+            .Select(c => c.Version)
+            .FirstOrDefaultAsync(cancellationToken) + 1;
+
+        _dbContext.CustomerChanges.Add(new CustomerChangeReadModel
+        {
+            Id = Guid.NewGuid(),
+            CustomerId = e.CustomerId,
+            Version = version,
+            Type = nameof(CustomerDetailsUpdatedDomainEvent),
+            OccurredOnUtc = e.OccurredOnUtc
+        });
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerPreferencesUpdatedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        var e = notification.Event;
+
+        var profile = await _dbContext.CustomerProfiles.FirstOrDefaultAsync(p => p.Id == e.CustomerId, cancellationToken);
+        if (profile is not null)
+        {
+            profile.EmailNotificationsEnabled = e.EmailNotificationsEnabled;
+            profile.SmsNotificationsEnabled = e.SmsNotificationsEnabled;
+        }
+
+        var prefs = await _dbContext.CustomerNotificationPreferences.FirstOrDefaultAsync(p => p.CustomerId == e.CustomerId, cancellationToken);
+        if (prefs is not null)
+        {
+            prefs.EmailNotificationsEnabled = e.EmailNotificationsEnabled;
+            prefs.SmsNotificationsEnabled = e.SmsNotificationsEnabled;
+        }
+
+        var version = await _dbContext.CustomerChanges
+            .Where(c => c.CustomerId == e.CustomerId)
+            .OrderByDescending(c => c.Version)
+            .Select(c => c.Version)
+            .FirstOrDefaultAsync(cancellationToken) + 1;
+
+        _dbContext.CustomerChanges.Add(new CustomerChangeReadModel
+        {
+            Id = Guid.NewGuid(),
+            CustomerId = e.CustomerId,
+            Version = version,
+            Type = nameof(CustomerPreferencesUpdatedDomainEvent),
+            OccurredOnUtc = e.OccurredOnUtc
+        });
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task Handle(ICommittedDomainEvent<CustomerDeletedDomainEvent> notification, CancellationToken cancellationToken)
+    {
+        var e = notification.Event;
+
+        var profile = await _dbContext.CustomerProfiles.FirstOrDefaultAsync(p => p.Id == e.CustomerId, cancellationToken);
+        if (profile is not null)
+        {
+            _dbContext.CustomerProfiles.Remove(profile);
+        }
+
+        var prefs = await _dbContext.CustomerNotificationPreferences.FirstOrDefaultAsync(p => p.CustomerId == e.CustomerId, cancellationToken);
+        if (prefs is not null)
+        {
+            _dbContext.CustomerNotificationPreferences.Remove(prefs);
+        }
+
+        var version = await _dbContext.CustomerChanges
+            .Where(c => c.CustomerId == e.CustomerId)
+            .OrderByDescending(c => c.Version)
+            .Select(c => c.Version)
+            .FirstOrDefaultAsync(cancellationToken) + 1;
+
+        _dbContext.CustomerChanges.Add(new CustomerChangeReadModel
+        {
+            Id = Guid.NewGuid(),
+            CustomerId = e.CustomerId,
+            Version = version,
+            Type = nameof(CustomerDeletedDomainEvent),
+            OccurredOnUtc = e.OccurredOnUtc
+        });
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerChange.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerChange.cs
@@ -1,0 +1,4 @@
+namespace Modules.Customer.Application.ReadModels;
+
+public sealed record CustomerChange(long Version, string Type, DateTimeOffset OccurredOnUtc);
+

--- a/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerNotificationPreferences.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerNotificationPreferences.cs
@@ -1,0 +1,7 @@
+namespace Modules.Customer.Application.ReadModels;
+
+public sealed record CustomerNotificationPreferences(
+    Guid Id,
+    bool EmailNotificationsEnabled,
+    bool SmsNotificationsEnabled);
+

--- a/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerProfile.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/ReadModels/CustomerProfile.cs
@@ -1,0 +1,11 @@
+namespace Modules.Customer.Application.ReadModels;
+
+public sealed record CustomerProfile(
+    Guid Id,
+    string Title,
+    string FirstName,
+    string LastName,
+    string Email,
+    bool EmailNotificationsEnabled,
+    bool SmsNotificationsEnabled);
+

--- a/src/Modules/Customer/Modules.Customer.Application/Services/CustomerReadService.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/Services/CustomerReadService.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using Application.Lifetimes;
+using Microsoft.EntityFrameworkCore;
+using Modules.Customer.Application.ReadModels;
+using Modules.Customer.Persistence;
+
+namespace Modules.Customer.Application.Services;
+
+public sealed class CustomerReadService(CustomerReadDbContext dbContext) : ICustomerReadService, ITransient
+{
+    private readonly CustomerReadDbContext _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+
+    public async Task<CustomerProfile?> GetProfileAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var profile = await _dbContext.CustomerProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == customerId, cancellationToken);
+        if (profile is null)
+        {
+            return null;
+        }
+
+        return new CustomerProfile(
+            profile.Id,
+            profile.Title,
+            profile.FirstName,
+            profile.LastName,
+            profile.Email,
+            profile.EmailNotificationsEnabled,
+            profile.SmsNotificationsEnabled);
+    }
+
+    public async Task<IReadOnlyList<CustomerChange>> GetChangeHistoryAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var history = await _dbContext.CustomerChanges
+            .AsNoTracking()
+            .Where(c => c.CustomerId == customerId)
+            .OrderBy(c => c.Version)
+            .ToListAsync(cancellationToken);
+        return history.Select(e => new CustomerChange(e.Version, e.Type, e.OccurredOnUtc)).ToList();
+    }
+
+    public async Task<CustomerNotificationPreferences?> GetNotificationPreferencesAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var prefs = await _dbContext.CustomerNotificationPreferences
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.CustomerId == customerId, cancellationToken);
+        if (prefs is null)
+        {
+            return null;
+        }
+
+        return new CustomerNotificationPreferences(
+            prefs.CustomerId,
+            prefs.EmailNotificationsEnabled,
+            prefs.SmsNotificationsEnabled);
+    }
+}
+

--- a/src/Modules/Customer/Modules.Customer.Application/Services/ICustomerReadService.cs
+++ b/src/Modules/Customer/Modules.Customer.Application/Services/ICustomerReadService.cs
@@ -1,0 +1,11 @@
+using Modules.Customer.Application.ReadModels;
+
+namespace Modules.Customer.Application.Services;
+
+public interface ICustomerReadService
+{
+    Task<CustomerProfile?> GetProfileAsync(Guid customerId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CustomerChange>> GetChangeHistoryAsync(Guid customerId, CancellationToken cancellationToken = default);
+    Task<CustomerNotificationPreferences?> GetNotificationPreferencesAsync(Guid customerId, CancellationToken cancellationToken = default);
+}
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Abstractions/ICustomerEventStore.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Abstractions/ICustomerEventStore.cs
@@ -1,0 +1,12 @@
+using Domain.Primitives;
+using Modules.Customer.Domain.Entities;
+
+namespace Modules.Customer.Domain.Abstractions;
+
+public interface ICustomerEventStore
+{
+    Task AppendAsync(Customer customer, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<IDomainEvent>> LoadAsync(Guid customerId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<StoredEvent>> GetHistoryAsync(Guid customerId, CancellationToken cancellationToken = default);
+}
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Abstractions/StoredEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Abstractions/StoredEvent.cs
@@ -1,0 +1,4 @@
+namespace Modules.Customer.Domain.Abstractions;
+
+public sealed record StoredEvent(string Type, string Data, long Version, DateTimeOffset OccurredOnUtc);
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Entities/ContactInformation.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Entities/ContactInformation.cs
@@ -1,5 +1,5 @@
-﻿using Domain.Primitives;
-
+using Domain.Primitives;
+using System.Text.Json.Serialization;
 
 namespace Modules.Customer.Domain.Entities;
 
@@ -15,7 +15,8 @@ public sealed class ContactInformation : Entity<Guid>
     public string Postcode { get; set; } = string.Empty;
     public string County { get; set; } = string.Empty;
     public string Country { get; set; } = string.Empty;
-    public Customer Customer { get; set; } = null!;
 
+    [JsonIgnore]
+    public Customer Customer { get; set; } = null!;
 }
 

--- a/src/Modules/Customer/Modules.Customer.Domain/Entities/Customer.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Entities/Customer.cs
@@ -1,17 +1,130 @@
 using Domain.Primitives;
-using Domain.ValueObjects;
-using System.Xml.Linq;
+using Modules.Customer.Domain.Events;
 
 namespace Modules.Customer.Domain.Entities;
-public sealed class Customer : Entity<Guid>
+
+public sealed class Customer : AggregateRoot<Guid>
 {
-    public Guid TenantId { get; set; }
-    public Guid UserId { get; set; }
-    public string Title { get; set; } = string.Empty;
-    public string FirstName { get; set; } = string.Empty;
-    public string LastName { get; set; } = string.Empty;
-    public DateOnly DateOfBirth { get; set; }
-    public string Gender { get; set; } = string.Empty;
-    public ContactInformation ContactInformation { get; set; } = null!;
-  
+    public Guid TenantId { get; private set; }
+    public Guid UserId { get; private set; }
+    public string Title { get; private set; } = string.Empty;
+    public string FirstName { get; private set; } = string.Empty;
+    public string LastName { get; private set; } = string.Empty;
+    public DateOnly DateOfBirth { get; private set; }
+    public string Gender { get; private set; } = string.Empty;
+    public ContactInformation ContactInformation { get; private set; } = new();
+    public bool EmailNotificationsEnabled { get; private set; }
+    public bool SmsNotificationsEnabled { get; private set; }
+
+    private Customer() { }
+
+    private Customer(Guid id) : base(id) { }
+
+    public static Customer Create(
+        Guid id,
+        Guid tenantId,
+        Guid userId,
+        string title,
+        string firstName,
+        string lastName,
+        DateOnly dateOfBirth,
+        string gender,
+        ContactInformation contactInformation,
+        bool emailNotificationsEnabled,
+        bool smsNotificationsEnabled)
+    {
+        var customer = new Customer(id);
+        var @event = new CustomerCreatedDomainEvent(
+            id,
+            tenantId,
+            userId,
+            title,
+            firstName,
+            lastName,
+            dateOfBirth,
+            gender,
+            contactInformation,
+            emailNotificationsEnabled,
+            smsNotificationsEnabled);
+        customer.ApplyChange(@event);
+        return customer;
+    }
+
+    public void UpdateDetails(
+        string title,
+        string firstName,
+        string lastName,
+        DateOnly dateOfBirth,
+        string gender,
+        ContactInformation contactInformation)
+    {
+        var @event = new CustomerDetailsUpdatedDomainEvent(
+            Id,
+            title,
+            firstName,
+            lastName,
+            dateOfBirth,
+            gender,
+            contactInformation);
+        ApplyChange(@event);
+    }
+
+    public void UpdatePreferences(bool emailNotificationsEnabled, bool smsNotificationsEnabled)
+    {
+        var @event = new CustomerPreferencesUpdatedDomainEvent(
+            Id,
+            emailNotificationsEnabled,
+            smsNotificationsEnabled);
+        ApplyChange(@event);
+    }
+
+    public void Delete()
+    {
+        var @event = new CustomerDeletedDomainEvent(Id);
+        ApplyChange(@event);
+    }
+
+    private void On(CustomerCreatedDomainEvent @event)
+    {
+        Id = @event.CustomerId;
+        TenantId = @event.TenantId;
+        UserId = @event.UserId;
+        Title = @event.Title;
+        FirstName = @event.FirstName;
+        LastName = @event.LastName;
+        DateOfBirth = @event.DateOfBirth;
+        Gender = @event.Gender;
+        ContactInformation = @event.ContactInformation;
+        EmailNotificationsEnabled = @event.EmailNotificationsEnabled;
+        SmsNotificationsEnabled = @event.SmsNotificationsEnabled;
+    }
+
+    private void On(CustomerDetailsUpdatedDomainEvent @event)
+    {
+        Title = @event.Title;
+        FirstName = @event.FirstName;
+        LastName = @event.LastName;
+        DateOfBirth = @event.DateOfBirth;
+        Gender = @event.Gender;
+        ContactInformation = @event.ContactInformation;
+    }
+
+    private void On(CustomerPreferencesUpdatedDomainEvent @event)
+    {
+        EmailNotificationsEnabled = @event.EmailNotificationsEnabled;
+        SmsNotificationsEnabled = @event.SmsNotificationsEnabled;
+    }
+
+    private void On(CustomerDeletedDomainEvent _)
+    {
+        DeletedAt = DateTime.UtcNow;
+    }
+
+    public static Customer Rehydrate(IEnumerable<IDomainEvent> events)
+    {
+        var customer = new Customer();
+        customer.Load(events);
+        return customer;
+    }
 }
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerCreatedDomainEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerCreatedDomainEvent.cs
@@ -1,0 +1,19 @@
+using Domain.Primitives;
+using Modules.Customer.Domain.Entities;
+
+namespace Modules.Customer.Domain.Events;
+
+public sealed record CustomerCreatedDomainEvent(
+    Guid CustomerId,
+    Guid TenantId,
+    Guid UserId,
+    string Title,
+    string FirstName,
+    string LastName,
+    DateOnly DateOfBirth,
+    string Gender,
+    ContactInformation ContactInformation,
+    bool EmailNotificationsEnabled,
+    bool SmsNotificationsEnabled
+) : DomainEvent(DateTimeOffset.UtcNow);
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerDeletedDomainEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerDeletedDomainEvent.cs
@@ -1,0 +1,8 @@
+using Domain.Primitives;
+
+namespace Modules.Customer.Domain.Events;
+
+public sealed record CustomerDeletedDomainEvent(
+    Guid CustomerId
+) : DomainEvent(DateTimeOffset.UtcNow);
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerDetailsUpdatedDomainEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerDetailsUpdatedDomainEvent.cs
@@ -1,0 +1,15 @@
+using Domain.Primitives;
+using Modules.Customer.Domain.Entities;
+
+namespace Modules.Customer.Domain.Events;
+
+public sealed record CustomerDetailsUpdatedDomainEvent(
+    Guid CustomerId,
+    string Title,
+    string FirstName,
+    string LastName,
+    DateOnly DateOfBirth,
+    string Gender,
+    ContactInformation ContactInformation
+) : DomainEvent(DateTimeOffset.UtcNow);
+

--- a/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerPreferencesUpdatedDomainEvent.cs
+++ b/src/Modules/Customer/Modules.Customer.Domain/Events/CustomerPreferencesUpdatedDomainEvent.cs
@@ -1,0 +1,10 @@
+using Domain.Primitives;
+
+namespace Modules.Customer.Domain.Events;
+
+public sealed record CustomerPreferencesUpdatedDomainEvent(
+    Guid CustomerId,
+    bool EmailNotificationsEnabled,
+    bool SmsNotificationsEnabled
+) : DomainEvent(DateTimeOffset.UtcNow);
+

--- a/src/Modules/Customer/Modules.Customer.Infrastructure/EventStore/CustomerEventStore.cs
+++ b/src/Modules/Customer/Modules.Customer.Infrastructure/EventStore/CustomerEventStore.cs
@@ -1,0 +1,86 @@
+using System.Text;
+using System.Text.Json;
+using Application.Lifetimes;
+using Domain.Primitives;
+using MediatR;
+using Modules.Customer.Domain.Abstractions;
+using Modules.Customer.Domain.Entities;
+
+namespace Modules.Customer.Infrastructure.EventStore;
+
+public sealed class CustomerEventStore(IKurrentClient client, IMediator mediator) : ICustomerEventStore, IScoped
+{
+    private readonly IKurrentClient _client = client ?? throw new ArgumentNullException(nameof(client));
+    private readonly IMediator _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task AppendAsync(Customer customer, CancellationToken cancellationToken = default)
+    {
+        var events = customer.DomainEvents;
+        var stream = $"customer-{customer.Id}";
+        var payload = events.Select(e => new KurrentEvent(
+            Guid.NewGuid(),
+            e.GetType().AssemblyQualifiedName!,
+            JsonSerializer.SerializeToUtf8Bytes(e, e.GetType(), _jsonOptions)));
+
+        await _client.AppendAsync(stream, payload, customer.Version - events.Count, cancellationToken);
+
+        foreach (var domainEvent in events)
+        {
+            var committedType = typeof(CommittedDomainEvent<>).MakeGenericType(domainEvent.GetType());
+            var committed = Activator.CreateInstance(committedType, domainEvent);
+            if (committed is INotification notification)
+            {
+                await _mediator.Publish(notification, cancellationToken);
+            }
+        }
+
+        customer.ClearDomainEvents();
+    }
+
+    public async Task<IReadOnlyList<IDomainEvent>> LoadAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var stream = $"customer-{customerId}";
+        var messages = await _client.ReadAsync(stream, cancellationToken);
+        var events = new List<IDomainEvent>();
+        foreach (var message in messages)
+        {
+            var type = Type.GetType(message.Type);
+            if (type is null)
+            {
+                continue;
+            }
+
+            var domainEvent = (IDomainEvent?)JsonSerializer.Deserialize(message.Data.Span, type, _jsonOptions);
+            if (domainEvent is not null)
+            {
+                events.Add(domainEvent);
+            }
+        }
+
+        return events;
+    }
+
+    public async Task<IReadOnlyList<StoredEvent>> GetHistoryAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        var stream = $"customer-{customerId}";
+        var messages = await _client.ReadAsync(stream, cancellationToken);
+        var history = new List<StoredEvent>();
+        foreach (var message in messages)
+        {
+            var data = Encoding.UTF8.GetString(message.Data.Span);
+            history.Add(new StoredEvent(message.Type, data, message.Version, message.OccurredOnUtc));
+        }
+        return history;
+    }
+}
+
+public record KurrentEvent(Guid Id, string Type, byte[] Data);
+
+public record KurrentMessage(string Type, ReadOnlyMemory<byte> Data, long Version, DateTimeOffset OccurredOnUtc);
+
+public interface IKurrentClient
+{
+    Task AppendAsync(string stream, IEnumerable<KurrentEvent> events, long expectedVersion, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<KurrentMessage>> ReadAsync(string stream, CancellationToken cancellationToken = default);
+}

--- a/src/Modules/Customer/Modules.Customer.Infrastructure/ServiceInstallers/PersistenceServiceInstaller.cs
+++ b/src/Modules/Customer/Modules.Customer.Infrastructure/ServiceInstallers/PersistenceServiceInstaller.cs
@@ -1,6 +1,7 @@
 namespace Modules.Customer.Infrastructure.ServiceInstallers;
 using Domain.Abstractions;
 using Modules.Customer.Infrastructure.Repository;
+using Modules.Customer.Persistence;
 
 internal sealed class PersistenceServiceInstaller : IServiceInstaller
 {
@@ -18,6 +19,16 @@ internal sealed class PersistenceServiceInstaller : IServiceInstaller
                 {
                     npgsqlOptions.UseRelationalNulls();
                 }).AddInterceptors(interceptor);
+            })
+            .AddDbContext<CustomerReadDbContext>((serviceProvider, options) =>
+            {
+                var connectionString = serviceProvider
+                    .GetRequiredService<IOptions<ConnectionStringOptions>>().Value;
+
+                options.UseNpgsql(connectionString, npgsqlOptions =>
+                {
+                    npgsqlOptions.UseRelationalNulls();
+                });
             })
             .AddScoped<ICustomerRepository, CustomerRepository>();
 

--- a/src/Modules/Customer/Modules.Customer.Persistence/CustomerReadDbContext.cs
+++ b/src/Modules/Customer/Modules.Customer.Persistence/CustomerReadDbContext.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Persistence.Extensions;
+using Modules.Customer.Persistence.ReadModels;
+
+namespace Modules.Customer.Persistence;
+
+public class CustomerReadDbContext : DbContext
+{
+    private readonly ILoggerFactory _loggerFactory;
+
+    public CustomerReadDbContext(ILoggerFactory loggerFactory, DbContextOptions<CustomerReadDbContext> options)
+        : base(options)
+    {
+        _loggerFactory = loggerFactory;
+    }
+
+    public DbSet<CustomerProfileReadModel> CustomerProfiles => Set<CustomerProfileReadModel>();
+    public DbSet<CustomerChangeReadModel> CustomerChanges => Set<CustomerChangeReadModel>();
+    public DbSet<CustomerNotificationPreferencesReadModel> CustomerNotificationPreferences => Set<CustomerNotificationPreferencesReadModel>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("customer");
+        modelBuilder.ToSnakeCaseTables();
+        modelBuilder.ApplyConfigurationsFromAssembly(AssemblyReference.Assembly);
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseLoggerFactory(_loggerFactory);
+#if DEBUG
+        optionsBuilder.EnableSensitiveDataLogging();
+#endif
+        optionsBuilder.EnableDetailedErrors();
+        optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+    }
+}

--- a/src/Modules/Customer/Modules.Customer.Persistence/ReadModels/CustomerChangeReadModel.cs
+++ b/src/Modules/Customer/Modules.Customer.Persistence/ReadModels/CustomerChangeReadModel.cs
@@ -1,0 +1,10 @@
+namespace Modules.Customer.Persistence.ReadModels;
+
+public class CustomerChangeReadModel
+{
+    public Guid Id { get; set; }
+    public Guid CustomerId { get; set; }
+    public long Version { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public DateTimeOffset OccurredOnUtc { get; set; }
+}

--- a/src/Modules/Customer/Modules.Customer.Persistence/ReadModels/CustomerNotificationPreferencesReadModel.cs
+++ b/src/Modules/Customer/Modules.Customer.Persistence/ReadModels/CustomerNotificationPreferencesReadModel.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Modules.Customer.Persistence.ReadModels;
+
+public class CustomerNotificationPreferencesReadModel
+{
+    [Key]
+    public Guid CustomerId { get; set; }
+    public bool EmailNotificationsEnabled { get; set; }
+    public bool SmsNotificationsEnabled { get; set; }
+}

--- a/src/Modules/Customer/Modules.Customer.Persistence/ReadModels/CustomerProfileReadModel.cs
+++ b/src/Modules/Customer/Modules.Customer.Persistence/ReadModels/CustomerProfileReadModel.cs
@@ -1,0 +1,12 @@
+namespace Modules.Customer.Persistence.ReadModels;
+
+public class CustomerProfileReadModel
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public bool EmailNotificationsEnabled { get; set; }
+    public bool SmsNotificationsEnabled { get; set; }
+}

--- a/src/Shared/Domain/Primitives/AggregateRoot.cs
+++ b/src/Shared/Domain/Primitives/AggregateRoot.cs
@@ -1,0 +1,55 @@
+namespace Domain.Primitives;
+
+/// <summary>
+/// Base class for aggregate roots supporting event sourcing.
+/// </summary>
+/// <typeparam name="TEntityId">The entity identifier type.</typeparam>
+public abstract class AggregateRoot<TEntityId> : Entity<TEntityId>, IAggregate<TEntityId>
+    where TEntityId : notnull
+{
+    protected AggregateRoot() { }
+
+    protected AggregateRoot(TEntityId id) : base(id) { }
+
+    /// <inheritdoc />
+    public IReadOnlyList<IDomainEvent> DomainEvents => GetDomainEvents();
+
+    /// <inheritdoc />
+    public long Version { get; set; } = -1;
+
+    /// <summary>
+    /// Applies and records a new domain event.
+    /// </summary>
+    /// <param name="domainEvent">The domain event.</param>
+    protected void ApplyChange(IDomainEvent domainEvent)
+    {
+        When(domainEvent);
+        RaiseDomainEvent(domainEvent);
+        Version++;
+    }
+
+    /// <summary>
+    /// Applies a historical event without recording it.
+    /// </summary>
+    /// <param name="domainEvent">The domain event.</param>
+    protected void Apply(IDomainEvent domainEvent)
+    {
+        When(domainEvent);
+        Version++;
+    }
+
+    /// <summary>
+    /// Loads the aggregate state from a sequence of domain events.
+    /// </summary>
+    /// <param name="history">The domain events history.</param>
+    public void Load(IEnumerable<IDomainEvent> history)
+    {
+        foreach (var domainEvent in history)
+        {
+            Apply(domainEvent);
+        }
+    }
+
+    private void When(IDomainEvent domainEvent) => ((dynamic)this).On((dynamic)domainEvent);
+}
+


### PR DESCRIPTION
## Summary
- introduce KurrentDB-backed event store for Customer aggregate
- persist customer read models in PostgreSQL and project domain events into query tables
- query current profiles, change history and notification preferences from Postgres read database

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad654f7e388328b5abdd76b243ec46